### PR TITLE
Setup deposit function and update account state

### DIFF
--- a/programs/margin-account/src/lib.rs
+++ b/programs/margin-account/src/lib.rs
@@ -1,19 +1,49 @@
 #![feature(proc_macro_hygiene)]
 
 use anchor_lang::prelude::*;
-use anchor_spl::token::{self, TokenAccount};
+use anchor_spl::token::{self, TokenAccount, Transfer};
 
 #[program]
 pub mod margin_account {
     use super::*;
 
+    /// Initialize new margin account under a specific trader's address.
     pub fn initialize(ctx: Context<Initialize>, trader: Pubkey) -> ProgramResult {
         let margin_account = &mut ctx.accounts.margin_account;
         margin_account.trader = trader;
         Ok(())
     }
-    pub fn deposit(_ctx: Context<Deposit>) -> ProgramResult {
-        // TODO
+    /// Deposit funds into a trader's margin account to use to trade.
+    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> ProgramResult {
+        // Transfer funds to the pool to be used for margin trades.
+        let cpi_accounts = Transfer {
+            from: ctx.accounts.from.to_account_info().clone(),
+            to: ctx.accounts.vault.to_account_info().clone(),
+            authority: ctx.accounts.authority.clone(),
+        };
+        let cpi_program = ctx.accounts.token_program.clone();
+        let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
+        token::transfer(cpi_ctx, amount)?;
+
+        // Add position to the margin account state
+        let mint = ctx.accounts.from.mint;
+        if let Some(pos) = ctx
+            .accounts
+            .margin_account
+            .tokens
+            .iter_mut()
+            .find(|p| p.mint == mint)
+        {
+            // Tokens are already deposited, add to this amount
+            pos.amount += amount;
+        } else {
+            // No tokens for this denom are deposited, create new
+            ctx.accounts
+                .margin_account
+                .tokens
+                .push(TokenDeposit { mint, amount });
+        }
+
         Ok(())
     }
     pub fn withdraw(_ctx: Context<Withdraw>) -> ProgramResult {
@@ -41,13 +71,20 @@ pub struct Initialize<'info> {
 /// Deposit funds into program account to be used for trading.
 #[derive(Accounts)]
 pub struct Deposit<'info> {
+    // TODO correct access control
+    #[account(mut)]
+    margin_account: ProgramAccount<'info, MarginAccount>,
     /// Authority (trader)
     #[account(signer)]
     authority: AccountInfo<'info>,
-    #[account(mut)]
+    /// Token account the check is made from.
+    #[account(mut, "from.mint == vault.mint")]
+    from: CpiAccount<'info, TokenAccount>,
+    /// Token vault for the trader's margin fund.
+    // TODO is the vault owned by the signer or liquidity pool?
+    #[account(mut, "&vault.owner == authority.key")]
     vault: CpiAccount<'info, TokenAccount>,
     // Misc.
-    #[account("token_program.key == &token::ID")]
     token_program: AccountInfo<'info>,
 }
 
@@ -59,7 +96,6 @@ pub struct Withdraw<'info> {
     #[account(mut)]
     vault: CpiAccount<'info, TokenAccount>,
     // Misc.
-    #[account("token_program.key == &token::ID")]
     token_program: AccountInfo<'info>,
 }
 
@@ -76,14 +112,32 @@ pub struct Liquidate<'info> {
     authority: AccountInfo<'info>,
 }
 
-/// Margin account which handles
+/// Margin account which accepts token deposits and allows the trader to open
+/// margin positions.
 #[account]
 pub struct MarginAccount {
     /// The owner of this margin account.
     pub trader: Pubkey,
     /// Address of the account's token vault.
+    // ! This probably won't be needed?
     pub vault: Pubkey,
-    /// Signer nonce.
-    pub nonce: u8,
-    // TODO need to account for open trade state
+    /// Token balances available to the margin account.
+    pub tokens: Vec<TokenDeposit>,
+    /// Open positions held by the margin account.
+    pub positions: Vec<Position>,
+}
+
+/// Deposits for the account to be used for opening trades.
+#[derive(Default, Clone, Copy, Debug, AnchorSerialize, AnchorDeserialize)]
+pub struct TokenDeposit {
+    /// Address of the token program for the position
+    pub mint: Pubkey,
+    /// Amount of minted tokens are added.
+    pub amount: u64,
+}
+
+/// Open margin trade position.
+#[derive(AnchorSerialize, AnchorDeserialize, Clone)]
+pub struct Position {
+    // TODO
 }

--- a/tests/margin.js
+++ b/tests/margin.js
@@ -35,6 +35,8 @@ describe("margin-account", () => {
   // const vault = new anchor.web3.Account();
 
   it("Initializes margin account", async () => {
+    // Arbitrary size for now, just need it to be large enough
+    const marginSize = 1200;
     await program.rpc.initialize(provider.wallet.publicKey, {
       accounts: {
         marginAccount: marginAcc.publicKey,
@@ -42,7 +44,7 @@ describe("margin-account", () => {
       },
       signers: [marginAcc],
       instructions: [
-        await program.account.marginAccount.createInstruction(marginAcc),
+        await program.account.marginAccount.createInstruction(marginAcc, marginSize),
       ],
     });
 


### PR DESCRIPTION
- Allows depositing funds into the pool and updating amounts on the margin account

TODO:
- Update to add a margin account state which specifies the liquidity pool address to constrain that the funds are sent to the right token account (this would probably need to be an interface on the liquidity pool later, and unclear what's the best interaction)
- Add test cases for the functionality added