### PR TITLE
Token pair whitelist access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ In this margin trade, a trader puts collateral into an obligation account and bo
 
 The trader can increase the amount of leverage, which increases the amount borrowed and swapped, but means the position can be liquidated if the price drops by a smaller amount. Liquidation can be triggered by any user on the network once the collateral and swapped tokens drops below the amount needed to swap and repay the loan with interest after slippage.
 
-The protocol includes lending pools, margin accounts, liquidation bots, an insurance fund and finally a governance mechanism. This is all wrapped up in a UI designed for ease of use.
+The protocol is built on [Solana](https://solana.com/) and includes lending pools, margin accounts, liquidation bots, an insurance fund and finally a governance mechanism. This is all wrapped up in a UI designed for ease of use.

--- a/programs/margin-account/src/lib.rs
+++ b/programs/margin-account/src/lib.rs
@@ -29,7 +29,8 @@ pub mod margin_account {
             })
         }
 
-        /// Should only be used as a temp function, state restricts
+        /// Should only be used as a temp function, state restricts from initializing with custom
+        /// size, so need to clear after initializing with default.
         #[access_control(whitelist_auth(self, &ctx))]
         pub fn clear_pairs(&mut self, ctx: Context<Auth>) -> Result<()> {
             self.token_pairs.clear();

--- a/tests/margin.js
+++ b/tests/margin.js
@@ -88,6 +88,26 @@ describe("margin-account", () => {
   // const vault = new anchor.web3.Account();
   let marginProgram = null
 
+  it("Initializes margin program state", async () => {
+    let accounts = {
+      authority: provider.wallet.publicKey,
+    };
+
+    await program.state.rpc.new({ accounts });
+    await program.state.rpc.clearPairs({ accounts });
+
+    let state = await program.state();
+    assert.ok(state.authority.equals(provider.wallet.publicKey));
+    assert.ok(state.tokenPairs.length == 0);
+
+    // Add token pair used for test
+    await program.state.rpc.addTokenPair(collateralMint, liquidityMint, { accounts });
+    state = await program.state();
+    assert.ok(state.tokenPairs.length === 1);
+    assert.ok(state.tokenPairs[0].firstToken.equals(collateralMint));
+    assert.ok(state.tokenPairs[0].secondToken.equals(liquidityMint));
+  });
+
   it("Initializes margin account", async () => {
     // Arbitrary size for now, just need it to be large enough
     const marginSize = 600;


### PR DESCRIPTION
- Restricts borrowing of tokens to the whitelist of pairs